### PR TITLE
Fix basic auth as Base64.toString() only prints the reference

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/auth/BasicAuthCipher.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/auth/BasicAuthCipher.java
@@ -38,7 +38,7 @@ public final class BasicAuthCipher extends AuthCipher {
     @Override
     public String token() {
         String token = username + ":" + password;
-        return Base64.encode(token.getBytes(), Base64.DEFAULT).toString();
+        return new String(Base64.encode(token.getBytes(), Base64.NO_WRAP));
     }
 
     public static final class Builder implements AuthCipher.Builder {


### PR DESCRIPTION
If basic auth is enabled with RTSP the authentication will fail as exoplayer tries to connect with a erroneously serialized base64 token.

In `BasicAuthCipher.java` the following expression is used to convert the `Base64` object into a string:
`Base64.encode(token.getBytes(), Base64.DEFAULT).toString()`

`Base64.encode()` returns a `byte[]` which will just return arrays reference name.
The correct way to convert the `byte[]` into a `String` is the constructor of the `String` class:
`new String(Base64.encode(token.getBytes(), Base64.NO_WRAP))`
