### PR TITLE
Fix authorization

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
@@ -348,6 +348,9 @@ import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_
                         Request request = outstanding.remove(cSeq);
                         requestMonitor.cancel(request);
 
+                        // clear header value lists to reuse the request object
+                        request.getHeaders().clear();
+
                         if (response.getStatus().equals(Status.Unauthorized)) {
                             listener.onUnauthorized(request, response);
 


### PR DESCRIPTION
With commit c1004bb6d4c7 request/response header values are lists now.

As requests are reused the header value lists have to be cleared.

Otherwise headers like Cseq will have duplicated entries, resulting in
sending e.g. Cseq=2 and Cseq=3 might in one request.