### PR TITLE
Fix RTSP live streaming and black artifacts

### DIFF
--- a/library/rtp/src/main/java/com/google/android/exoplayer2/source/rtp/extractor/RtpH264PayloadReader.java
+++ b/library/rtp/src/main/java/com/google/android/exoplayer2/source/rtp/extractor/RtpH264PayloadReader.java
@@ -80,7 +80,7 @@ import java.util.List;
     private String formatId;
 
     public RtpH264PayloadReader(RtpVideoPayload payloadFormat) {
-        this(payloadFormat, true, true);
+        this(payloadFormat, false, true);
     }
 
     public RtpH264PayloadReader(RtpVideoPayload payloadFormat,
@@ -196,9 +196,8 @@ import java.util.List;
 
         //Log.v("RtpH264PayloadReader", "[Single] NAL unit type=[" + nalUnitType + "]");
 
-        if (nalUnitType == NAL_UNIT_TYPE_IDR || nalUnitType == NAL_UNIT_TYPE_NON_IDR) {
-            sampleIsKeyframe = true;
-        }
+        sampleIsKeyframe = (nalUnitType == NAL_UNIT_TYPE_IDR
+                || (allowNonIdrKeyframes && nalUnitType == NAL_UNIT_TYPE_NON_IDR));
 
         if (hasOutputFormat) {
             nalStartCode.setPosition(0);
@@ -300,7 +299,8 @@ import java.util.List;
 
                 if (hasOutputFormat) {
                     sampleLength += data.length;
-                    sampleIsKeyframe = true;
+                    sampleIsKeyframe = (nalUnitType == NAL_UNIT_TYPE_IDR
+                            || (allowNonIdrKeyframes && nalUnitType == NAL_UNIT_TYPE_NON_IDR));
 
                     output.sampleData(new ParsableByteArray(data), data.length);
 


### PR DESCRIPTION
Non-IDR NAL Units were handled as keyframes although they aren't.
This resulted in black screens with partial movement artifacts, e.g.
when streaming started as the non-keyframes were used although the
video information was not complete.
Sometimes the non-keyframes (handled as keyframes) also overwrote the
keyframes so that for tens of seconds only a black screen was visible.

**Note:**
I am not sure if allowNonIdrKeyframes should be the default. As it did not work reliable for me I set it to "false". There might be a reason that it was "true" before.