### PR TITLE
Fix the bug causing app crash with some RTSP servers

### DIFF
--- a/library/sdp/src/main/java/com/google/android/exoplayer2/source/sdp/core/Time.java
+++ b/library/sdp/src/main/java/com/google/android/exoplayer2/source/sdp/core/Time.java
@@ -49,13 +49,13 @@ public class Time {
 
     private static long getSecondsFromTypedTime(String typedTime) {
         if (typedTime.endsWith("d")) {
-            return Integer.parseInt(typedTime.replace('d', ' ').trim()) * 86400;
+            return Long.parseLong(typedTime.replace('d', ' ').trim()) * 86400;
         } else if (typedTime.endsWith("h")) {
-            return Integer.parseInt(typedTime.replace('h', ' ').trim()) * 3600;
+            return Long.parseLong(typedTime.replace('h', ' ').trim()) * 3600;
         } else if (typedTime.endsWith("m")) {
-            return Integer.parseInt(typedTime.replace('m', ' ').trim()) * 60;
+            return Long.parseLong(typedTime.replace('m', ' ').trim()) * 60;
         } else {
-            return Integer.parseInt(typedTime.replace('s', ' ').trim());
+            return Long.parseLong(typedTime.replace('s', ' ').trim());
         }
     }
 


### PR DESCRIPTION
Serveral RTSP servers returning Long timestamp in its SDP packet, which causes in this case NumberFormatException.

e.g. 
Exception in thread "main" java.lang.NumberFormatException: For input string: "3794842336".

Such exception causes decoding of SDP failed and makes the demo app crash conseqently .