### PR TITLE
Use BaseUri as the request Url when making the GET_PARAMETER request

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
@@ -181,7 +181,7 @@ public final class RtspDefaultClient extends Client {
 
     @Override
     public void sendPlayRequest(Range range) {
-        Request.Builder builder = new Request.Builder().play().url(getPlayUrl());
+        Request.Builder builder = new Request.Builder().play().url(getDescribeUrl());
         builder.header(Header.CSeq, session.nextCSeq());
         builder.header(Header.UserAgent, USER_AGENT);
         builder.header(Header.Session, session.getId());
@@ -192,7 +192,7 @@ public final class RtspDefaultClient extends Client {
 
     @Override
     public void sendPlayRequest(Range range, float scale) {
-        Request.Builder builder = new Request.Builder().play().url(getPlayUrl());
+        Request.Builder builder = new Request.Builder().play().url(getDescribeUrl());
         builder.header(Header.CSeq, session.nextCSeq());
         builder.header(Header.UserAgent, USER_AGENT);
         builder.header(Header.Session, session.getId());
@@ -219,7 +219,7 @@ public final class RtspDefaultClient extends Client {
 
     @Override
     protected void sendGetParameterRequest() {
-        Request.Builder builder = new Request.Builder().get_parameter().url(session.getBaseUri().toString());
+        Request.Builder builder = new Request.Builder().get_parameter().url(getDescribeUrl());
         builder.header(Header.CSeq, session.nextCSeq());
         builder.header(Header.UserAgent, USER_AGENT);
         builder.header(Header.Session, session.getId());

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
@@ -219,7 +219,7 @@ public final class RtspDefaultClient extends Client {
 
     @Override
     protected void sendGetParameterRequest() {
-        Request.Builder builder = new Request.Builder().get_parameter().url(session.uri().toString());
+        Request.Builder builder = new Request.Builder().get_parameter().url(session.getBaseUri().toString());
         builder.header(Header.CSeq, session.nextCSeq());
         builder.header(Header.UserAgent, USER_AGENT);
         builder.header(Header.Session, session.getId());

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspDefaultClient.java
@@ -234,7 +234,7 @@ public final class RtspDefaultClient extends Client {
 
     @Override
     public void sendTeardownRequest() {
-        Request.Builder builder = new Request.Builder().teardown().url(session.uri().toString());
+        Request.Builder builder = new Request.Builder().teardown().url(getDescribeUrl());
         builder.header(Header.CSeq, session.nextCSeq());
         builder.header(Header.UserAgent, USER_AGENT);
         builder.header(Header.Session, session.getId());

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Client.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Client.java
@@ -879,7 +879,7 @@ public abstract class Client implements Dispatcher.EventListener {
         return false;
     }
 
-    protected final String getPlayUrl() {
+    protected final String getDescribeUrl() {
         // determine the URL to use for PLAY requests
         Uri baseUri = session.getBaseUri();
         if (baseUri != null) {

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
@@ -139,6 +139,8 @@ import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_
             opened = false;
 
             sender.cancel();
+            sender.awaitTermination();
+
             receiver.cancel();
             requestMonitor.stop();
 

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
@@ -366,7 +366,8 @@ import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_
                     } else {
 
                         Response.Builder builder = new Response.Builder().status(Status.BadRequest);
-                        builder.header(Header.UserAgent, userAgent);
+                        builder.header(Header.UserAgent, userAgent == null ?
+                                "": userAgent);
 
                         execute(builder.build());
                     }


### PR DESCRIPTION
This ensures that the Url used is the one returned from the DESCRIBE request

This was the previous behaviour when speaking to a Live555 RTSP Server

Request:
`V/Sender: DESCRIBE rtsp://user:password@127.0.0.1:554/video?input=0&transmission=unicast RTSP/1.0
    uri="rtsp://user:password@127.0.0.1:554/video?input=0&transmission=unicast"`
Response:
`V/Receiver: RTSP/1.0 200 OK
    Content-Base: rtsp://127.0.0.1/video?input=0&profile=primary&transmission=unicast/`

after some time streaming

Request:
`V/Sender: GET_PARAMETER rtsp://user:password@127.0.0.1:554/video?input=0&transmission=unicast RTSP/1.0
   uri="rtsp://user:password@10.0.2.2:554/video?input=0&transmission=unicast"`
Response:
`V/Receiver: RTSP/1.0 404 Not Found`

As you can see `rtsp://127.0.0.1/video?input=0&transmission=unicast/` is missing the `profile=primary` part of the request string resulting in a 404