### PR TITLE
RTSPS

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/core/Dispatcher.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
 
 import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_0;
 
@@ -118,7 +119,11 @@ import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_
 
     public void connect() throws IOException {
         if (!opened) {
-            socket = SocketFactory.getDefault().createSocket();
+            if ("rtsps".equals(uri.getScheme())) {
+                socket = SSLSocketFactory.getDefault().createSocket();
+            } else {
+                socket = SocketFactory.getDefault().createSocket();
+            }
 
             address = InetAddress.getByName(uri.getHost());
 
@@ -418,7 +423,7 @@ import static com.google.android.exoplayer2.source.rtsp.message.Protocol.RTSP_1_
      * Monitor the request/reply message.
      */
     /* package */ final class RequestMonitor {
-        private static final long DEFAULT_TIMEOUT_REQUEST = 10000;
+        private static final long DEFAULT_TIMEOUT_REQUEST = 20000;
 
         private final ExecutorService executorService = Executors.newSingleThreadExecutor();
         private final Map<Integer, Future<?>> tasks;

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/message/Request.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/message/Request.java
@@ -94,7 +94,7 @@ public final class Request extends Message {
         public Builder url(String url) {
             if (url == null) throw new NullPointerException("url is null");
 
-            if (url.regionMatches(true, 0, "rtsp:", 0, 5) || url.equals("*")) {
+            if (url.regionMatches(true, 0, "rtsp:", 0, 5) || url.regionMatches(true, 0, "rtsps:", 0, 6) || url.equals("*")) {
                 this.url = url;
             } else {
                 if (url.contains("://")) {


### PR DESCRIPTION
Adds support RTSPS (RTSP over TLS).

Tested with Nest camera stream and it works. That's also why the timeout is increased to 20 seconds, because it look like their RTSP server has some rate limiting. I've got the `DESCRIBE` response in exacly 10.1 seconds.